### PR TITLE
Fix layouts for admin.

### DIFF
--- a/lib/spree_multi_domain/engine.rb
+++ b/lib/spree_multi_domain/engine.rb
@@ -22,15 +22,17 @@ module SpreeMultiDomain
         def find_layout_with_multi_store(layout, locals)
           if @view.respond_to?(:current_store) && @view.current_store && !@view.controller.is_a?(Spree::Admin::BaseController) && layout.call.present?
             store_layout = if layout.is_a?(String)
-              layout.gsub("layouts/", "layouts/#{@view.current_store.code}/")
-            else
-              layout.call.try(:gsub, "layouts/", "layouts/#{@view.current_store.code}/")
-            end
-          end
+                             layout.gsub("layouts/", "layouts/#{@view.current_store.code}/")
+                           else
+                             layout.call.try(:gsub, "layouts/", "layouts/#{@view.current_store.code}/")
+                           end
 
-          begin
-            find_layout_without_multi_store(store_layout, locals)
-          rescue ::ActionView::MissingTemplate
+            begin
+              find_layout_without_multi_store(store_layout, locals)
+            rescue ::ActionView::MissingTemplate
+              find_layout_without_multi_store(layout, locals)
+            end
+          else
             find_layout_without_multi_store(layout, locals)
           end
         end


### PR DESCRIPTION
Calling `find_layout(nil, locals)` will return `nil` and not throw a missing template exception. Which means we just lost the valid layout we originally had and replaced it with nothing.
