### PR TITLE
DRY up PaymentMethod#available decoration

### DIFF
--- a/app/models/spree/payment_method_decorator.rb
+++ b/app/models/spree/payment_method_decorator.rb
@@ -2,12 +2,12 @@ Spree::PaymentMethod.class_eval do
   has_many :store_payment_methods
   has_many :stores, :through => :store_payment_methods
 
-  def self.available(display_on = 'both', store = nil)
-    result = all.select do |p|
-      p.active &&
-        (p.environment == Rails.env || p.environment.blank?) &&
-        (store.nil? || store.payment_methods.empty? || store.payment_methods.include?(p)) &&
-        (p.display_on == display_on.to_s || p.display_on.blank?)
+  class << self
+    alias_method :available_without_store, :available
+    def available(display_on = 'both', store = nil)
+      available_without_store(display_on).select do |p|
+        store.nil? || store.payment_methods.empty? || store.payment_methods.include?(p)
+      end
     end
   end
 end


### PR DESCRIPTION
Rather than copy & pasting code, call the original method and further filter the list of available payment methods from there. This way, if the upstream logic changes those changes aren't overridden by solidus_multi_domain.

I think this is better in this case as it's simpler than the full-on extension point.