### PR TITLE
Alternative to monkey patching PaymentMethod.available

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,5 +1,9 @@
 Spree::Order.class_eval do
   def available_payment_methods
-    @available_payment_methods ||= Spree::PaymentMethod.available(:front_end, store)
+    @available_payment_methods ||=
+      SpreeMultiDomain.payment_methods_by_store(
+        Spree::PaymentMethod.available(:front_end),
+        store,
+      )
   end
 end

--- a/app/models/spree/payment_method_decorator.rb
+++ b/app/models/spree/payment_method_decorator.rb
@@ -1,13 +1,4 @@
 Spree::PaymentMethod.class_eval do
   has_many :store_payment_methods
   has_many :stores, :through => :store_payment_methods
-
-  def self.available(display_on = 'both', store = nil)
-    result = all.select do |p|
-      p.active &&
-        (p.environment == Rails.env || p.environment.blank?) &&
-        (store.nil? || store.payment_methods.empty? || store.payment_methods.include?(p)) &&
-        (p.display_on == display_on.to_s || p.display_on.blank?)
-    end
-  end
 end

--- a/lib/solidus_multi_domain.rb
+++ b/lib/solidus_multi_domain.rb
@@ -1,3 +1,13 @@
 require 'sass/rails'
 require 'spree_core'
 require 'spree_multi_domain/engine'
+
+module SpreeMultiDomain
+  def self.payment_methods_by_store(payment_methods, store)
+    payment_methods.select do |p|
+      store.nil? ||
+        store.payment_methods.empty? ||
+        store.payment_methods.include?(p)
+    end
+  end
+end

--- a/spec/solidus_multi_domain_spec.rb
+++ b/spec/solidus_multi_domain_spec.rb
@@ -1,8 +1,13 @@
 require 'spec_helper'
 
-describe 'PaymentMethod' do
-  describe '.available' do
-    subject { Spree::PaymentMethod.available(:front_end, store) }
+describe 'SpreeMultiDomain' do
+  describe '.payment_methods_by_store' do
+    subject do
+      SpreeMultiDomain.payment_methods_by_store(
+        Spree::PaymentMethod.available(:front_end),
+        store,
+      )
+    end
 
     let!(:check_payment_method) { FactoryGirl.create :check_payment_method }
     let(:payment_method_store) { FactoryGirl.create :store, :payment_methods => [check_payment_method] }


### PR DESCRIPTION
I wanted to throw this out as an alternative way to do https://github.com/solidusio/solidus_multi_domain/pull/13.  This is what I was trying to describe in earlier comments.

Upsides:

- Doesn't modify code that isn't ours
- When called, it's more apparent what's happening and where the code is coming from
- More straightforwardly compatible with other extensions.  i.e. multiple extensions could have something like this and we wouldn't have to come up with a method signature that could support anything (e.g. an `options={}` hash in the method signature)
- Any code that called the old form can just as easily call the new form
- Should be more re-usable -- in more places than just `PaymentMethod.available`

Downsides:

- Less convenient (more verbose to type)

Thoughts?  Other downsides or upsides that I'm missing?