### PR TITLE
Update Solidus dependency

### DIFF
--- a/solidus_multi_domain.gemspec
+++ b/solidus_multi_domain.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
-  s.add_dependency "solidus", [">= 1.0.0.pre", "< 2"]
+  s.add_dependency "solidus", [">= 1.1.0.pre", "< 2"]
 
   s.add_development_dependency "rspec-rails",  "~> 3.2"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
The recent PaymentMethod update:
https://github.com/solidusio/solidus_multi_domain/pull/16
depends on code that is only in Solidus >= 1.1.0.

Assuming this is merged I'm planning on updating the version of this gem from 1.0.2 to 1.1.0 and yanking 1.0.2 from rubygems (since it really is broken with the existing incorrect dependency).