### PR TITLE
Fix for payment environment removal

### DIFF
--- a/app/views/spree/admin/stores/_form.html.erb
+++ b/app/views/spree/admin/stores/_form.html.erb
@@ -66,7 +66,7 @@
           <label class="sub">
             <%= check_box_tag 'store[payment_method_ids][]', payment_method.id, @store.payment_methods.include?(payment_method) %>
           </label> &nbsp;
-          <%= "#{payment_method.name} (#{payment_method.environment})" %>
+          <%= payment_method.name %>
           <br>
         <% end %>
         <%= hidden_field_tag 'store[payment_method_ids][]', '' %>

--- a/spec/controllers/spree/admin/stores_controller_spec.rb
+++ b/spec/controllers/spree/admin/stores_controller_spec.rb
@@ -3,11 +3,22 @@ require 'spec_helper'
 describe Spree::Admin::StoresController do
   stub_authorization!
 
-  describe "on :index" do
+  describe '#index' do
     render_views
 
-    it "renders index" do
+    it 'renders' do
       spree_get :index
+      expect(response).to be_success
+    end
+  end
+
+  describe '#edit' do
+    render_views
+
+    let(:store) { create(:store) }
+
+    it 'renders' do
+      spree_get :edit, id: store.to_param
       expect(response).to be_success
     end
   end

--- a/spec/controllers/spree/admin/stores_controller_spec.rb
+++ b/spec/controllers/spree/admin/stores_controller_spec.rb
@@ -4,6 +4,8 @@ describe Spree::Admin::StoresController do
   stub_authorization!
 
   describe "on :index" do
+    render_views
+
     it "renders index" do
       spree_get :index
       expect(response).to be_success


### PR DESCRIPTION
Remove payment_method.environment from Admin::StoresController#index

This was removed from Solidus.

Also, fix issue w/ rendering views in spec/dummy app.