### PR TITLE
Remove overly strict gemspec requirements

### DIFF
--- a/solidus_multi_domain.gemspec
+++ b/solidus_multi_domain.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-rails",  "~> 3.2"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency "sass-rails", "~> 4.0.2"
-  s.add_development_dependency "coffee-rails", "~> 4.0.0"
-  s.add_development_dependency "factory_girl", "~> 4.5.0"
-  s.add_development_dependency "capybara", "~> 2.4"
+  s.add_development_dependency "sass-rails"
+  s.add_development_dependency "coffee-rails"
+  s.add_development_dependency "factory_girl", "~> 4.5"
+  s.add_development_dependency "capybara"
   s.add_development_dependency "ffaker"
 end


### PR DESCRIPTION
Old sass-rails and coffee-rails versions were preventing us from using bourbon 4.0