### PR TITLE
bump solidus version dependency to 1.2 (and bump gem version at the s…

### DIFF
--- a/solidus_multi_domain.gemspec
+++ b/solidus_multi_domain.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "solidus_multi_domain"
-  s.version     = "1.1.2"
+  s.version     = "1.1.3"
   s.summary     = "Adds multiple site support to Solidus"
   s.description = "Multiple Solidus stores on different domains - single unified backed for processing orders."
   s.required_ruby_version = ">= 2.1"
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
-  s.add_dependency "solidus", '~> 1.1'
+  s.add_dependency "solidus", '~> 1.2'
 
   s.add_development_dependency "rspec-rails",  "~> 3.2"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
Current gem does not work with Solidus 1.2

> Bundler could not find compatible versions for gem "solidus":
>   In Gemfile:
>     solidus_multi_domain (= 1.1.2) ruby depends on
>       solidus (~> 1.1) ruby