### PR TITLE
Update paperclip paths for store model

### DIFF
--- a/app/models/spree/store_decorator.rb
+++ b/app/models/spree/store_decorator.rb
@@ -11,8 +11,8 @@ Spree::Store.class_eval do
   has_attached_file :logo,
     styles: { mini: '48x48>', small: '100x100>', medium: '250x250>' },
     default_style: :medium,
-    url: 'stores/:id/:style/:basename.:extension',
-    path: 'stores/:id/:style/:basename.:extension',
+    url: '/spree/stores/:id/:style/:basename.:extension',
+    path: ':rails_root/public/spree/stores/:id/:style/:basename.:extension',
     convert_options: { all: '-strip -auto-orient' }
 
   validates_attachment_file_name :logo, matches: [/png\Z/i, /jpe?g\Z/i],


### PR DESCRIPTION
What I changed is inline with what is on solidus core for regular images: https://github.com/solidusio/solidus/blob/e15ca73e8f7083633343f0678023695a96e24d31/core/app/models/spree/image.rb#L9

Moreover, how it was would not correctly path to an image, since it was the root directory, not under `/public`.