### PR TITLE
use `current_store` when looking up the Spree::Tracker

### DIFF
--- a/app/models/spree/tracker_decorator.rb
+++ b/app/models/spree/tracker_decorator.rb
@@ -1,7 +1,7 @@
 Spree::Tracker.class_eval do
   belongs_to :store
 
-  def self.current(store_key)
-    Spree::Tracker.where(active: true).joins(:store).where("spree_stores.code = ? OR spree_stores.url LIKE ?", store_key, "%#{store_key}%").first
+  def self.current(store)
+    Spree::Tracker.where(active: true, store_id: store).first
   end
 end

--- a/lib/spree_multi_domain/multi_domain_helpers.rb
+++ b/lib/spree_multi_domain/multi_domain_helpers.rb
@@ -10,7 +10,7 @@ module SpreeMultiDomain
     end
 
     def current_tracker
-      @current_tracker ||= Spree::Tracker.current(store_key)
+      @current_tracker ||= Spree::Tracker.current(current_store)
     end
 
     def get_taxonomies
@@ -21,11 +21,6 @@ module SpreeMultiDomain
 
     def add_current_store_id_to_params
       params[:current_store_id] = current_store.try(:id)
-    end
-
-    private
-    def store_key
-      request.headers['HTTP_SPREE_STORE'] || request.env['SERVER_NAME']
     end
   end
 end

--- a/spec/models/spree/tracker_spec.rb
+++ b/spec/models/spree/tracker_spec.rb
@@ -9,11 +9,7 @@ describe Spree::Tracker do
     @tracker2 = FactoryGirl.create(:tracker, store: @another_store)
   end
 
-  it "pulls out the current tracker based on store code" do
-    expect(Spree::Tracker.current('STORE2')).to eq @tracker2
-  end
-
-  it "pulls out the current tracker" do
-    expect(Spree::Tracker.current(@store.url)).to eq @tracker
+  it "finds tracker by store" do
+    expect(Spree::Tracker.current(@store)).to eq @tracker
   end
 end


### PR DESCRIPTION
This will allow us to depend completely on the configured `current_store_class` or the default `Spree::Core::CurrentStore`