### PR TITLE
Allow apps to use factory_overrides.rb for their own specs

### DIFF
--- a/lib/spree_multi_domain/testing_support/factory_overrides.rb
+++ b/lib/spree_multi_domain/testing_support/factory_overrides.rb
@@ -1,8 +1,8 @@
 FactoryGirl.modify do
   # Products need to belong to the same store as the order.
   factory :line_item do
-    before(:create) do |line_item, evaluator|
-      if line_item.order.store
+    after(:build) do |line_item, evaluator|
+      if line_item.order.store && line_item.product.stores.empty?
         line_item.product.stores << line_item.order.store
       end
     end

--- a/spec/lib/spree_multi_domain/testing_support/factory_overrides_spec.rb
+++ b/spec/lib/spree_multi_domain/testing_support/factory_overrides_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe "spree core factories should not raise ProductDoesNotBelongToStoreError" do
+  it "should be able to build a line_item" do
+    expect { build(:line_item) }.not_to raise_error
+  end
+
+  it "should be able to create a line_item" do
+    expect { create(:line_item) }.not_to raise_error
+  end
+
+  it "should be able to create a line_item with a specified variant" do
+    expect { create(:line_item, variant: create(:variant, price: 100.00)) }.not_to raise_error
+  end
+
+  it "should be able to build an inventory_unit" do
+    expect { build(:inventory_unit) }.not_to raise_error
+  end
+
+  it "should be able to create an inventory_unit" do
+    expect { create(:inventory_unit) }.not_to raise_error
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require 'ffaker'
 
 # Requires factories defined in spree_core
 require 'spree/testing_support/factories'
+require 'spree_multi_domain/testing_support/factory_overrides'
 require 'spree/testing_support/controller_requests'
 require 'spree/testing_support/authorization_helpers'
 require 'spree/testing_support/preferences'


### PR DESCRIPTION
It's pretty typical for your solidus app to use solidus factories in its specs/tests.
But if you're using solidus_multi_domain, you will also need to modify the `:line_item` factory to make sure the `order` and `variant` belong to the same store.

`spec/support/factory_overrides.rb` has the necessary changes, but it's not available to use in an application.

Solution is to move this to `lib/spree_multi_domain/testing_support/factory_overrides.rb`, and in your app's `spec_helper.rb` add this line after requiring the spree factories:
`require 'spree_multi_domain/testing_support/factory_overrides'`