### PR TITLE
Ensure the required Spree engines are included before decorating classes.

### DIFF
--- a/app/controllers/spree/admin/products_controller_decorator.rb
+++ b/app/controllers/spree/admin/products_controller_decorator.rb
@@ -2,11 +2,11 @@ Spree::Admin::ProductsController.class_eval do
   update.before :set_stores
 
   private
+
   def set_stores
     # Remove all store associations if store data is being passed and no stores are selected
     if params[:update_store_ids] && !params[:product].key?(:store_ids)
       @product.stores.clear
     end
   end
-
-end
+end if SpreeMultiDomain::Engine.admin_available?

--- a/app/controllers/spree/api/line_items_controller_decorator.rb
+++ b/app/controllers/spree/api/line_items_controller_decorator.rb
@@ -1,1 +1,3 @@
-Spree::Api::LineItemsController.include SpreeMultiDomain::CreateLineItemSupport
+if SpreeMultiDomain::Engine.api_available?
+  Spree::Api::LineItemsController.include(SpreeMultiDomain::CreateLineItemSupport)
+end

--- a/app/controllers/spree/api/products_controller_decorator.rb
+++ b/app/controllers/spree/api/products_controller_decorator.rb
@@ -1,1 +1,3 @@
-Spree::Api::ProductsController.include(SpreeMultiDomain::ShowProductSupport)
+if SpreeMultiDomain::Engine.api_available?
+  Spree::Api::ProductsController.include(SpreeMultiDomain::ShowProductSupport)
+end

--- a/app/controllers/spree/api/shipments_controller_decorator.rb
+++ b/app/controllers/spree/api/shipments_controller_decorator.rb
@@ -13,5 +13,7 @@ module SpreeMultiStore
   end
 end
 
-Spree::Api::ShipmentsController.include SpreeMultiStore::Api::ShipmentsControllerDecorator
-Spree::Api::ShipmentsController.include SpreeMultiDomain::CreateLineItemSupport
+if SpreeMultiDomain::Engine.api_available?
+  Spree::Api::ShipmentsController.include(SpreeMultiStore::Api::ShipmentsControllerDecorator)
+  Spree::Api::ShipmentsController.include(SpreeMultiDomain::CreateLineItemSupport)
+end

--- a/app/controllers/spree/home_controller_decorator.rb
+++ b/app/controllers/spree/home_controller_decorator.rb
@@ -4,4 +4,4 @@ Spree::HomeController.class_eval do
     @products = @searcher.retrieve_products
     @taxonomies = get_taxonomies
   end
-end
+end if SpreeMultiDomain::Engine.frontend_available?

--- a/app/controllers/spree/products_controller_decorator.rb
+++ b/app/controllers/spree/products_controller_decorator.rb
@@ -1,1 +1,3 @@
-Spree::ProductsController.include(SpreeMultiDomain::ShowProductSupport)
+if SpreeMultiDomain::Engine.frontend_available?
+  Spree::ProductsController.include(SpreeMultiDomain::ShowProductSupport)
+end

--- a/app/controllers/spree/taxons_controller_decorator.rb
+++ b/app/controllers/spree/taxons_controller_decorator.rb
@@ -7,4 +7,4 @@ Spree::TaxonsController.class_eval do
     @products = @searcher.retrieve_products
     @taxonomies = get_taxonomies
   end
-end
+end if SpreeMultiDomain::Engine.frontend_available?


### PR DESCRIPTION
* Excluding the `Spree::Frontend::Engine` from an application results in errors.
* Monkeypatch only when then engine containing the patched class has been included.