### PR TITLE
Add stricter dependency on deface to fix bundler

### DIFF
--- a/solidus_multi_domain.gemspec
+++ b/solidus_multi_domain.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.requirements << "none"
 
   s.add_dependency "solidus", ['>= 1.1', '< 3']
-  s.add_dependency "deface"
+  s.add_dependency "deface", '~> 1.0'
 
   s.add_development_dependency "rspec-rails",  "~> 3.2"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
I suspect that bundler 1.13.0 and 1.13.1 have broken dependency resolution. Without this change, bundler spins for 10 minutes before giving errors resolving dependencies of the rails components.

Adding this restriction seems to kick it into working, even though it should have been free to pick deface 1.0.1 without this change.

![](http://i.hawth.ca/u/bundler.png)