### PR TITLE
Switch to rails 5 spec keyword request syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ gem "solidus", github: "solidusio/solidus", branch: branch
 
 if branch == 'master' || branch >= "v2.0"
   gem "rails-controller-testing", group: :test
+else
+  gem "rails", '~> 4.2.0'
+  gem "rails_test_params_backport", group: :test
 end
 
 gem 'pg'

--- a/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spec/controllers/spree/admin/products_controller_spec.rb
@@ -5,7 +5,7 @@ describe Spree::Admin::ProductsController do
 
   describe "on :index" do
     it "renders index" do
-      spree_get :index
+      get :index
       expect(response).to be_success
     end
   end
@@ -20,7 +20,7 @@ describe Spree::Admin::ProductsController do
       it "clears stores if they previously existed" do
         @product.stores << @store
 
-        spree_put :update, :id => @product.to_param,
+        put :update, :id => @product.to_param,
                       :product => {:name => @product.name}, update_store_ids: 'true'
 
         expect(@product.reload.store_ids).to be_empty
@@ -29,7 +29,7 @@ describe Spree::Admin::ProductsController do
 
     describe "when a store is selected" do
       it "clears stores" do
-        spree_put :update, :id => @product.to_param,
+        put :update, :id => @product.to_param,
                       :product => {:name => @product.name, :store_ids => [@store.id]}, update_store_ids: 'true'
 
         expect(@product.reload.store_ids).to eq [@store.id]

--- a/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spec/controllers/spree/admin/products_controller_spec.rb
@@ -20,8 +20,12 @@ describe Spree::Admin::ProductsController do
       it "clears stores if they previously existed" do
         @product.stores << @store
 
-        put :update, :id => @product.to_param,
-                      :product => {:name => @product.name}, update_store_ids: 'true'
+        put :update,
+          params: {
+            :id => @product.to_param,
+            :product => {:name => @product.name},
+            update_store_ids: 'true'
+          }
 
         expect(@product.reload.store_ids).to be_empty
       end
@@ -29,8 +33,12 @@ describe Spree::Admin::ProductsController do
 
     describe "when a store is selected" do
       it "clears stores" do
-        put :update, :id => @product.to_param,
-                      :product => {:name => @product.name, :store_ids => [@store.id]}, update_store_ids: 'true'
+        put :update,
+          params: {
+            :id => @product.to_param,
+            :product => {:name => @product.name, :store_ids => [@store.id]},
+            update_store_ids: 'true'
+          }
 
         expect(@product.reload.store_ids).to eq [@store.id]
       end

--- a/spec/controllers/spree/admin/stores_controller_spec.rb
+++ b/spec/controllers/spree/admin/stores_controller_spec.rb
@@ -7,7 +7,7 @@ describe Spree::Admin::StoresController do
     render_views
 
     it 'renders' do
-      spree_get :index
+      get :index
       expect(response).to be_success
     end
   end
@@ -18,7 +18,7 @@ describe Spree::Admin::StoresController do
     let(:store) { create(:store) }
 
     it 'renders' do
-      spree_get :edit, id: store.to_param
+      get :edit, id: store.to_param
       expect(response).to be_success
     end
   end

--- a/spec/controllers/spree/admin/stores_controller_spec.rb
+++ b/spec/controllers/spree/admin/stores_controller_spec.rb
@@ -18,7 +18,7 @@ describe Spree::Admin::StoresController do
     let(:store) { create(:store) }
 
     it 'renders' do
-      get :edit, id: store.to_param
+      get :edit, params: { id: store.to_param }
       expect(response).to be_success
     end
   end

--- a/spec/controllers/spree/api/line_items_controller_spec.rb
+++ b/spec/controllers/spree/api/line_items_controller_spec.rb
@@ -12,7 +12,7 @@ describe Spree::Api::LineItemsController do
     let(:order) { create(:order, user: user) }
     let(:line_item) { build(:line_item, order: order) }
 
-    subject { post :create, line_item: line_item, order_id: line_item.order.number }
+    subject { post :create, params: { line_item: line_item, order_id: line_item.order.number } }
 
     context "A SpreeMultiDomain::LineItemDecorator::ProductDoesNotBelongToStoreError is raised" do
       before(:each) do

--- a/spec/controllers/spree/api/line_items_controller_spec.rb
+++ b/spec/controllers/spree/api/line_items_controller_spec.rb
@@ -12,7 +12,7 @@ describe Spree::Api::LineItemsController do
     let(:order) { create(:order, user: user) }
     let(:line_item) { build(:line_item, order: order) }
 
-    subject { spree_post :create, line_item: line_item, order_id: line_item.order.number }
+    subject { post :create, line_item: line_item, order_id: line_item.order.number }
 
     context "A SpreeMultiDomain::LineItemDecorator::ProductDoesNotBelongToStoreError is raised" do
       before(:each) do

--- a/spec/controllers/spree/api/products_controller_spec.rb
+++ b/spec/controllers/spree/api/products_controller_spec.rb
@@ -11,7 +11,7 @@ describe Spree::Api::ProductsController do
     let!(:store) { FactoryGirl.create(:store) }
 
     it 'should return 404' do
-      spree_get :show, :id => product.to_param, format: :json
+      get :show, :id => product.to_param, format: :json
 
       expect(response.response_code) == 404
     end
@@ -28,7 +28,7 @@ describe Spree::Api::ProductsController do
 
     it 'should return 404' do
       allow(controller).to receive_messages(:current_store => store_2)
-      spree_get :show, :id => product.to_param, format: :json
+      get :show, :id => product.to_param, format: :json
 
       expect(response.response_code) == 404
     end
@@ -43,7 +43,7 @@ describe Spree::Api::ProductsController do
 
     it 'should return 200' do
       allow(controller).to receive_messages(:current_store => store)
-      spree_get :show, :id => product.to_param, format: :json
+      get :show, :id => product.to_param, format: :json
 
       expect(response.response_code) == 200
     end

--- a/spec/controllers/spree/api/products_controller_spec.rb
+++ b/spec/controllers/spree/api/products_controller_spec.rb
@@ -11,7 +11,7 @@ describe Spree::Api::ProductsController do
     let!(:store) { FactoryGirl.create(:store) }
 
     it 'should return 404' do
-      get :show, :id => product.to_param, format: :json
+      get :show, params: { :id => product.to_param, format: :json }
 
       expect(response.response_code) == 404
     end
@@ -28,7 +28,7 @@ describe Spree::Api::ProductsController do
 
     it 'should return 404' do
       allow(controller).to receive_messages(:current_store => store_2)
-      get :show, :id => product.to_param, format: :json
+      get :show, params: { :id => product.to_param , format: :json }
 
       expect(response.response_code) == 404
     end
@@ -43,7 +43,7 @@ describe Spree::Api::ProductsController do
 
     it 'should return 200' do
       allow(controller).to receive_messages(:current_store => store)
-      get :show, :id => product.to_param, format: :json
+      get :show, params: { :id => product.to_param , format: :json }
 
       expect(response.response_code) == 200
     end

--- a/spec/controllers/spree/api/shipments_controller_spec.rb
+++ b/spec/controllers/spree/api/shipments_controller_spec.rb
@@ -36,7 +36,7 @@ describe Spree::Api::ShipmentsController do
     let(:shipment) { create(:shipment) }
     let(:variant) { create(:variant) }
 
-    subject { spree_put :add, variant_id: variant.id, id: shipment.number, quantity: 1 }
+    subject { put :add, variant_id: variant.id, id: shipment.number, quantity: 1 }
 
     before(:each) do
       stub_authentication!

--- a/spec/controllers/spree/api/shipments_controller_spec.rb
+++ b/spec/controllers/spree/api/shipments_controller_spec.rb
@@ -36,7 +36,7 @@ describe Spree::Api::ShipmentsController do
     let(:shipment) { create(:shipment) }
     let(:variant) { create(:variant) }
 
-    subject { put :add, variant_id: variant.id, id: shipment.number, quantity: 1 }
+    subject { put :add, params: { variant_id: variant.id, id: shipment.number, quantity: 1 } }
 
     before(:each) do
       stub_authentication!

--- a/spec/controllers/spree/products_controller_spec.rb
+++ b/spec/controllers/spree/products_controller_spec.rb
@@ -8,7 +8,7 @@ describe Spree::ProductsController do
     let!(:store) { FactoryGirl.create(:store) }
 
     it 'returns 404' do
-      get :show, :id => product.to_param
+      get :show, params: { :id => product.to_param }
 
       expect(response.response_code).to eq 404
     end
@@ -25,7 +25,7 @@ describe Spree::ProductsController do
 
     it 'returns 404' do
       allow(controller).to receive_messages(:current_store => store_2)
-      get :show, :id => product.to_param
+      get :show, params: { :id => product.to_param }
 
       expect(response.response_code).to eq 404
     end
@@ -40,7 +40,7 @@ describe Spree::ProductsController do
 
     it 'returns 200' do
       allow(controller).to receive_messages(:current_store => store)
-      get :show, :id => product.to_param
+      get :show, params: { :id => product.to_param }
 
       expect(response.response_code).to eq 200
     end

--- a/spec/controllers/spree/products_controller_spec.rb
+++ b/spec/controllers/spree/products_controller_spec.rb
@@ -8,7 +8,7 @@ describe Spree::ProductsController do
     let!(:store) { FactoryGirl.create(:store) }
 
     it 'returns 404' do
-      spree_get :show, :id => product.to_param
+      get :show, :id => product.to_param
 
       expect(response.response_code).to eq 404
     end
@@ -25,7 +25,7 @@ describe Spree::ProductsController do
 
     it 'returns 404' do
       allow(controller).to receive_messages(:current_store => store_2)
-      spree_get :show, :id => product.to_param
+      get :show, :id => product.to_param
 
       expect(response.response_code).to eq 404
     end
@@ -40,7 +40,7 @@ describe Spree::ProductsController do
 
     it 'returns 200' do
       allow(controller).to receive_messages(:current_store => store)
-      spree_get :show, :id => product.to_param
+      get :show, :id => product.to_param
 
       expect(response.response_code).to eq 200
     end


### PR DESCRIPTION
This adds the rails_test_params_backport gem which allows us to write requests in specs using the :params, :headers and :env options introduced in Rails 5.

This allows the same specs to run on both rails 4.2 and rails 5 without generating deprecation warnings.