### PR TITLE
Remove deprecated icon links from backend

### DIFF
--- a/app/views/spree/admin/stores/edit.html.erb
+++ b/app/views/spree/admin/stores/edit.html.erb
@@ -6,7 +6,7 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to Spree.t(:back_to_store_list), spree.admin_stores_path, :icon => 'icon-arrow-left' %>
+    <%= button_link_to Spree.t(:back_to_store_list), spree.admin_stores_path %>
   </li>
 <% end %>
 

--- a/app/views/spree/admin/stores/index.html.erb
+++ b/app/views/spree/admin/stores/index.html.erb
@@ -7,7 +7,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Store) %>
     <li>
-      <%= button_link_to Spree.t(:new_store), new_object_url,  :icon => 'icon-plus', :id => 'admin_new_store_link' %>
+      <%= button_link_to Spree.t(:new_store), new_object_url, :id => 'admin_new_store_link' %>
     </li>
   <% end %>
 <% end %>

--- a/app/views/spree/admin/stores/new.html.erb
+++ b/app/views/spree/admin/stores/new.html.erb
@@ -6,7 +6,7 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to Spree.t(:back_to_store_list), spree.admin_stores_path, :icon => 'icon-arrow-left' %>
+    <%= button_link_to Spree.t(:back_to_store_list), spree.admin_stores_path %>
   </li>
 <% end %>
 


### PR DESCRIPTION
This PR just removes deprecated icons used in backend to match current Solidus backend style