### PR TITLE
[WIP] Add a class that selects the store using requests info.

### DIFF
--- a/app/models/spree/multi_domain_store_selector.rb
+++ b/app/models/spree/multi_domain_store_selector.rb
@@ -1,0 +1,26 @@
+# Class for deciding what the current store is, given an HTTP request
+module Spree
+  class MultiDomainStoreSelector
+    def initialize(request)
+      @request = request
+    end
+
+    # Chooses the current store based on a request.
+    # Checks request headers for HTTP_SPREE_STORE and falls back to
+    # looking up by the requesting server's name.
+    # @return [Spree::Store]
+    def store
+      if store_key
+        Spree::Store.current(store_key)
+      else
+        Spree::Store.default
+      end
+    end
+
+    private
+
+    def store_key
+      @request.headers['HTTP_SPREE_STORE'] || @request.env['SERVER_NAME']
+    end
+  end
+end

--- a/lib/spree_multi_domain/engine.rb
+++ b/lib/spree_multi_domain/engine.rb
@@ -12,8 +12,21 @@ module SpreeMultiDomain
           end
         end
 
+        # Previous versions of solidus have the multi domain store selection
+        # logic directly in core (called Spree::Core::CurrentStore or
+        # Spree::CurrentStoreSelector). As long as Spree::Config responds to
+        # current_store_selector_class we can use the new domain selector
+        # class safely.
+        if store_selector_class?
+          Spree::Config.current_store_selector_class = Spree::MultiDomainStoreSelector
+        end
+
         Spree::Config.searcher_class = Spree::Search::MultiDomain
         ApplicationController.send :include, SpreeMultiDomain::MultiDomainHelpers
+      end
+
+      def store_selector_class?
+        Spree::Config.respond_to?(:current_store_selector_class)
       end
 
       def admin_available?

--- a/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/spec/controllers/spree/api/orders_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Spree::Api::OrdersController do
+  describe '#mine' do
+    let!(:user) { create(:user) }
+    let!(:store1) { create(:store) }
+    let!(:store2) { create(:store) }
+    let!(:order_from_store1) { create(:order, store: store1, user: user) }
+    let!(:order_from_store2) { create(:order, store: store2, user: user) }
+
+    before(:each) do
+      allow(controller).to receive_messages(current_api_user: user)
+    end
+
+    it 'returns only orders from the correct store' do
+      allow(controller).to receive_messages(current_store: store1)
+      controller.mine
+
+      expect(assigns(:orders).length).to eq(1)
+      expect(assigns(:orders).first.store_id).to eq(store1.id)
+
+      allow(controller).to receive_messages(current_store: store2)
+      controller.mine
+
+      expect(assigns(:orders).length).to eq(1)
+      expect(assigns(:orders).first.store_id).to eq(store2.id)
+    end
+  end
+end

--- a/spec/models/spree/multi_domain_store_selector_spec.rb
+++ b/spec/models/spree/multi_domain_store_selector_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe Spree::MultiDomainStoreSelector do
+  describe "#store" do
+    subject { Spree::MultiDomainStoreSelector.new(request).store }
+
+    context "with a default" do
+      let(:request) { double(headers: {}, env: {}) }
+      let!(:store_1) { create :store, default: true }
+
+      it "returns the default store" do
+        expect(subject).to eq(store_1)
+      end
+
+      context "with a domain match" do
+        let(:request) { double(headers: {}, env: { "SERVER_NAME" => url } ) }
+        let(:url) { "server-name.org" }
+        let!(:store_2) { create :store, default: false, url: url }
+
+        it "returns the store with the matching domain" do
+          expect(subject).to eq(store_2)
+        end
+
+        context "with headers" do
+          let(:request) { double(headers: { "HTTP_SPREE_STORE" => headers_code }, env: {}) }
+          let(:headers_code) { "HEADERS" }
+          let!(:store_3) { create :store, code: headers_code, default: false }
+
+          it "returns the store with the matching code" do
+            expect(subject).to eq(store_3)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This class logic is extracted from Solidus core, which is going
to be simplified a lot to avoid multiple queries at each request
if solidus_multi_domain extension is not used (solidusio/solidus#1971).