### PR TITLE
Limit support to Solidus 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ env:
     - SOLIDUS_BRANCH=v2.2 DB=postgres
     - SOLIDUS_BRANCH=v2.3 DB=postgres
     - SOLIDUS_BRANCH=v2.4 DB=postgres
-    - SOLIDUS_BRANCH=v2.5 DB=postgres
-    - SOLIDUS_BRANCH=master DB=postgres
     - SOLIDUS_BRANCH=v1.1 DB=mysql
     - SOLIDUS_BRANCH=v1.2 DB=mysql
     - SOLIDUS_BRANCH=v1.3 DB=mysql
@@ -24,5 +22,3 @@ env:
     - SOLIDUS_BRANCH=v2.2 DB=mysql
     - SOLIDUS_BRANCH=v2.3 DB=mysql
     - SOLIDUS_BRANCH=v2.4 DB=mysql
-    - SOLIDUS_BRANCH=v2.5 DB=mysql
-    - SOLIDUS_BRANCH=master DB=mysql

--- a/solidus_multi_domain.gemspec
+++ b/solidus_multi_domain.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
-  s.add_dependency "solidus", ['>= 1.1', '< 3']
+  s.add_dependency "solidus", ['>= 1.1', '< 2.5.x']
   s.add_dependency "solidus_support"
   s.add_dependency "deface", '~> 1.0'
 


### PR DESCRIPTION
Solidus 2.5 introduces a number of features currently provided by this extension. We're going to want to cut a major release that provides compatibility with that version of Solidus.