### PR TITLE
Fix travis Issues with Factory Bot, Rails 5.2 and Solidus >= v2.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
@@ -10,11 +12,20 @@ else
   gem "rails_test_params_backport", group: :test
 end
 
-gem 'pg', '~> 0.21'
-gem 'mysql2', '~> 0.4.10'
+if ENV['DB'] == 'mysql'
+  gem 'mysql2', '~> 0.4.10'
+else
+  gem 'pg', '~> 0.21'
+end
 
 group :development, :test do
   gem "pry-rails"
+
+  if branch < "v2.5"
+    gem 'factory_bot', '4.10.0'
+  else
+    gem 'factory_bot', '> 4.10.0'
+  end
 end
 
 gemspec

--- a/app/views/spree/admin/stores/_form.html.erb
+++ b/app/views/spree/admin/stores/_form.html.erb
@@ -50,7 +50,7 @@
   </div>
 
   <div class="eight columns">
-    <%= image_tag @store.logo %>
+    <%= image_tag @store.logo.url %>
     <%= f.field_container :logo do %>
       <%= f.label :logo, Spree.t(:logo) %><br />
       <%= f.file_field :logo %>

--- a/db/migrate/20130325231147_add_store_shipping_methods.rb
+++ b/db/migrate/20130325231147_add_store_shipping_methods.rb
@@ -1,5 +1,9 @@
+# frozen_string_literal: true
+
 class AddStoreShippingMethods < SolidusSupport::Migration[4.2]
-  def change
+  def self.up
+    return if table_exists?(:spree_store_shipping_methods)
+
     create_table :spree_store_shipping_methods do |t|
       t.integer :store_id
       t.integer :shipping_method_id
@@ -9,6 +13,10 @@ class AddStoreShippingMethods < SolidusSupport::Migration[4.2]
 
     add_index :spree_store_shipping_methods, :store_id
     add_index :spree_store_shipping_methods, :shipping_method_id
+  end
+
+  def self.down
+    drop_table :spree_store_shipping_methods
   end
 end
 

--- a/db/migrate/20130412212659_add_spree_promotion_rules_stores.rb
+++ b/db/migrate/20130412212659_add_spree_promotion_rules_stores.rb
@@ -1,8 +1,16 @@
+# frozen_string_literal: true
+
 class AddSpreePromotionRulesStores < SolidusSupport::Migration[4.2]
-  def change
+  def self.up
+    return if table_exists?(:spree_promotion_rules_stores)
+
     create_table :spree_promotion_rules_stores, :id => false do |t|
       t.references :promotion_rule
       t.references :store
     end
+  end
+
+  def self.down
+    drop_table :spree_promotion_rules_stores
   end
 end

--- a/db/migrate/20150304200122_add_indexes.rb
+++ b/db/migrate/20150304200122_add_indexes.rb
@@ -1,6 +1,18 @@
+# frozen_string_literal: true
+
 class AddIndexes < SolidusSupport::Migration[4.2]
-  def change
-    add_index :spree_promotion_rules_stores, :store_id
-    add_index :spree_promotion_rules_stores, :promotion_rule_id
+  def self.up
+    unless index_exists?(:spree_promotion_rules_stores, :store_id)
+      add_index :spree_promotion_rules_stores, :store_id
+    end
+
+    unless index_exists?(:spree_promotion_rules_stores, :promotion_rule_id)
+      add_index :spree_promotion_rules_stores, :promotion_rule_id
+    end
+  end
+
+  def self.down
+    remove_index :spree_promotion_rules_stores, :store_id
+    remove_index :spree_promotion_rules_stores, :promotion_rule_id
   end
 end

--- a/solidus_multi_domain.gemspec
+++ b/solidus_multi_domain.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "sass-rails"
   s.add_development_dependency "coffee-rails"
-  s.add_development_dependency "factory_bot", "~> 4.5"
   s.add_development_dependency "capybara", "~> 2.18"
   s.add_development_dependency "poltergeist"
   s.add_development_dependency "capybara-screenshot"


### PR DESCRIPTION
For Solidus versions older than `v2.5` gem `factory_bot 4.10.0` must be used
for compatibility.