### PR TITLE
Replace Spree.t with I18n.t

### DIFF
--- a/app/controllers/concerns/spree_multi_domain/create_line_item_support.rb
+++ b/app/controllers/concerns/spree_multi_domain/create_line_item_support.rb
@@ -10,7 +10,7 @@ module SpreeMultiDomain::CreateLineItemSupport
     private
 
     def product_does_not_belong_to_store
-      render json: { message: Spree.t('errors.products_from_different_stores_may_not_be_added_to_this_order') }, status: 422
+      render json: { message: I18n.t('spree.errors.products_from_different_stores_may_not_be_added_to_this_order') }, status: 422
     end
   end
 end

--- a/app/views/spree/admin/stores/_form.html.erb
+++ b/app/views/spree/admin/stores/_form.html.erb
@@ -1,7 +1,7 @@
 <div data-hook="admin_store_form_fields">
   <div class="alpha four columns">
     <%= f.field_container :name do %>
-      <%= f.label :name, Spree.t(:store_name) %><br />
+      <%= f.label :name, I18n.t('spree.store_name') %><br />
       <%= f.text_field :name, :class => 'fullwidth' %>
       <%= error_message_on :store, :name %>
     <% end %>
@@ -9,7 +9,7 @@
 
   <div class="four columns">
     <%= f.field_container :code do %>
-      <%= f.label :code, Spree.t(:store_code) %><br />
+      <%= f.label :code, I18n.t('spree.store_code') %><br />
       <%= f.text_field :code, :class => 'fullwidth' %>
       <%= error_message_on :store, :code %>
     <% end %>
@@ -17,10 +17,10 @@
 
   <div class="two columns">
     <%= f.field_container :default do %>
-      <%= f.label :default, Spree.t(:default) %>
+      <%= f.label :default, I18n.t('spree.default') %>
       <ul>
-        <li><%= f.radio_button :default, "true", :class => 'fullwidth' %> <%= Spree.t(:say_yes) %></li>
-        <li><%= f.radio_button :default, "false", :class => 'fullwidth' %> <%= Spree.t(:say_no) %></li>
+        <li><%= f.radio_button :default, "true", :class => 'fullwidth' %> <%= I18n.t('spree.say_yes') %></li>
+        <li><%= f.radio_button :default, "false", :class => 'fullwidth' %> <%= I18n.t('spree.say_no') %></li>
       </ul>
       <%= error_message_on :store, :default %>
     <% end %>
@@ -28,7 +28,7 @@
 
   <div class="four columns">
     <%= f.field_container :mail_from_address do %>
-      <%= f.label :mail_from_address, Spree.t(:send_mails_as) %><br />
+      <%= f.label :mail_from_address, I18n.t('spree.send_mails_as') %><br />
       <%= f.text_field :mail_from_address, :class => 'fullwidth' %>
       <%= error_message_on :store, :mail_from_address %>
     <% end %>
@@ -36,14 +36,14 @@
 
   <div class="four columns">
     <%= f.field_container :default_currency do %>
-      <%= f.label :default_currency, Spree.t(:default_currency) %>
+      <%= f.label :default_currency, I18n.t('spree.default_currency') %>
       <%= f.text_field :default_currency %>
     <% end %>
   </div>
 
   <div class="six columns">
     <%= f.field_container :url do %>
-      <%= f.label :url, Spree.t(:domains) %><br />
+      <%= f.label :url, I18n.t('spree.domains') %><br />
       <%= f.text_area :url, :cols => 60, :rows => 4, :class => 'fullwidth' %>
       <%= error_message_on :store, :url %>
     <% end %>
@@ -52,7 +52,7 @@
   <div class="eight columns">
     <%= image_tag @store.logo.url %>
     <%= f.field_container :logo do %>
-      <%= f.label :logo, Spree.t(:logo) %><br />
+      <%= f.label :logo, I18n.t('spree.logo') %><br />
       <%= f.file_field :logo %>
       <%= error_message_on :store, :logo %>
     <% end %>
@@ -61,7 +61,7 @@
   <div class='row'>
     <div class="alpha six columns">
       <%= f.field_container :payment_methods do %>
-        <%= f.label :payment_methods, Spree.t(:payment_methods) %><br />
+        <%= f.label :payment_methods, I18n.t('spree.payment_methods') %><br />
         <% @payment_methods.each do |payment_method| %>
           <label class="sub">
             <%= check_box_tag 'store[payment_method_ids][]', payment_method.id, @store.payment_methods.include?(payment_method) %>
@@ -75,7 +75,7 @@
 
     <div class="omega six columns">
       <%= f.field_container :shipping_methods do %>
-        <%= f.label :shipping_methods, Spree.t(:shipping_methods) %><br />
+        <%= f.label :shipping_methods, I18n.t('spree.shipping_methods') %><br />
         <% @shipping_methods.each do |shipping_method| %>
           <label class="sub">
             <%= check_box_tag 'store[shipping_method_ids][]', shipping_method.id, @store.shipping_methods.include?(shipping_method) %>

--- a/app/views/spree/admin/stores/edit.html.erb
+++ b/app/views/spree/admin/stores/edit.html.erb
@@ -1,12 +1,12 @@
 <%= render :partial => 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_store) %>
+  <%= I18n.t('spree.editing_store') %>
 <% end %>
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to Spree.t(:back_to_store_list), spree.admin_stores_path, :icon => 'icon-arrow-left' %>
+    <%= link_to I18n.t('spree.back_to_store_list'), spree.admin_stores_path, :icon => 'icon-arrow-left' %>
   </li>
 <% end %>
 

--- a/app/views/spree/admin/stores/index.html.erb
+++ b/app/views/spree/admin/stores/index.html.erb
@@ -1,13 +1,13 @@
 <%= render :partial => 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:stores) %>
+  <%= I18n.t('spree.stores') %>
 <% end %>
 
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Store) %>
     <li>
-      <%= button_link_to Spree.t(:new_store), new_object_url,  :icon => 'icon-plus', :id => 'admin_new_store_link' %>
+      <%= link_to I18n.t('spree.new_store'), new_object_url, :icon => 'icon-plus', :id => 'admin_new_store_link' %>
     </li>
   <% end %>
 <% end %>
@@ -21,10 +21,10 @@
     <col style="width: 15%">
   </colgroup>
   <thead>
-    <th><%= Spree.t(:store_name) %></th>
-    <th><%= Spree.t(:store_code) %></th>
-    <th><%= Spree.t(:send_mails_as) %></th>
-    <th><%= Spree.t(:domains) %></th>
+    <th><%= I18n.t('spree.store_name') %></th>
+    <th><%= I18n.t('spree.store_code') %></th>
+    <th><%= I18n.t('spree.send_mails_as') %></th>
+    <th><%= I18n.t('spree.domains') %></th>
     <th data-hook="admin_stores_index_header_actions" class="actions"></th>
   </thead>
   <tbody>

--- a/app/views/spree/shared/_multi_domain_sidebar_entry.html.erb
+++ b/app/views/spree/shared/_multi_domain_sidebar_entry.html.erb
@@ -1,3 +1,3 @@
 <% if can?(:display, Spree::Store) %>
-  <%= configurations_sidebar_menu_item Spree.t(:stores_admin), admin_stores_url %>
+  <%= configurations_sidebar_menu_item I18n.t('spree.stores_admin'), admin_stores_url %>
 <% end %>


### PR DESCRIPTION
This PR fixes several deprecation warnings by replacing the now-deprecated `Spree.t` with `I18n.t`.

The Travis build is currently failing because of **one** spec, but a fix is available via #95.