### PR TITLE
Fix Travis build

### DIFF
--- a/solidus_multi_domain.gemspec
+++ b/solidus_multi_domain.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rspec-rails",  "~> 3.2"
   s.add_development_dependency "simplecov"
-  s.add_development_dependency "sqlite3"
+  s.add_development_dependency "sqlite3", '~> 1.3.6'
   s.add_development_dependency "sass-rails"
   s.add_development_dependency "coffee-rails"
   s.add_development_dependency "capybara", "~> 2.18"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,8 @@ require 'cancan/matchers'
 
 Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }
 
+FactoryBot.use_parent_strategy = false
+
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.mock_with :rspec


### PR DESCRIPTION
This PR aims to get a green Travis build again by introducing the following changes:

* Lock SQLite3 to version 1.3 (see commit's description for details)
* Set `FactoryBot.use_parent_strategy` to `false` (see commit's description for details)